### PR TITLE
Add awaits, add dependency for ignite-dev-screens

### DIFF
--- a/boilerplate.js
+++ b/boilerplate.js
@@ -111,7 +111,7 @@ async function install (context) {
    * Append to files
    */
   // https://github.com/facebook/react-native/issues/12724
-  filesystem.appendAsync('.gitattributes', '*.bat text eol=crlf')
+  await filesystem.appendAsync('.gitattributes', '*.bat text eol=crlf')
   filesystem.append('.gitignore', '\n# Misc\n#')
   filesystem.append('.gitignore', '\n.env\n')
 
@@ -242,7 +242,7 @@ async function install (context) {
 
     // TODO: Make husky hooks optional
     const huskyCmd = '' // `&& node node_modules/husky/bin/install .`
-    system.run(`git init . && git add . && git commit -m "Initial commit." ${huskyCmd}`)
+    await system.run(`git init . && git add . && git commit -m "Initial commit." ${huskyCmd}`)
 
     spinner.succeed(`configured git`)
   }

--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -24,6 +24,7 @@
     "querystringify": "1.0.0",
     "ramda": "^0.25.0",
     "react-native-config": "^0.10.0",
+    "react-native-device-info": "^0.24.3",
     "react-navigation-redux-helpers": "^2.0.6",
     "react-redux": "^5.0.6",
     "redux": "^4.0.0",


### PR DESCRIPTION
• Adds `awaits` to async functions. (their absence was causing missing dev screens)
• Adds `react-native-device-info`, which is required in order for `ignite-dev-screens` to work. The DeviceInfo screen uses this.