### PR TITLE
fix version specification for ignite plugins

### DIFF
--- a/boilerplate.js
+++ b/boilerplate.js
@@ -198,17 +198,17 @@ async function install (context) {
       '  }'
     })
     if (answers['vector-icons'] === 'react-native-vector-icons') {
-      await system.spawn(`ignite add vector-icons@"~>1.0.0" ${debugFlag}`, {
+      await system.spawn(`ignite add vector-icons@1.1.1 ${debugFlag}`, {
         stdio: 'inherit'
       })
     }
 
     if (answers['i18n'] === 'react-native-i18n') {
-      await system.spawn(`ignite add i18n@"~>1.0.0" ${debugFlag}`, { stdio: 'inherit' })
+      await system.spawn(`ignite add i18n@1.2.0 ${debugFlag}`, { stdio: 'inherit' })
     }
 
     if (answers['animatable'] === 'react-native-animatable') {
-      await system.spawn(`ignite add animatable@"~>1.0.0" ${debugFlag}`, {
+      await system.spawn(`ignite add animatable@1.0.2 ${debugFlag}`, {
         stdio: 'inherit'
       })
     }
@@ -216,19 +216,19 @@ async function install (context) {
     // dev-screens be installed after vector-icons and animatable so that it can
     // conditionally patch its PluginExamplesScreen
     if (answers['dev-screens'] === 'Yes') {
-      await system.spawn(`ignite add dev-screens@"~>2.3.0" ${debugFlag}`, {
+      await system.spawn(`ignite add dev-screens@"2.4.3" ${debugFlag}`, {
         stdio: 'inherit'
       })
     }
 
     if (answers['redux-persist'] === 'Yes') {
-      await system.spawn(`ignite add redux-persist@"~>5.10.0" ${debugFlag}`, {
+      await system.spawn(`ignite add redux-persist@1.1.2 ${debugFlag}`, {
         stdio: 'inherit'
       })
     }
 
     if (parameters.options.lint !== 'false') {
-      await system.spawn(`ignite add standard@"~>1.0.0" ${debugFlag}`, {
+      await system.spawn(`ignite add standard@1.0.0 ${debugFlag}`, {
         stdio: 'inherit'
       })
     }


### PR DESCRIPTION
Ignite was recently updated to allow version specifications, which caused Andross to install the specified versions of plugins rather than the latest.  

This specifically affects:
 - `ignite-dev-screens@2.3.0` which installs an incompatible `react-navigation` (fixed in v2.4.2).
 - `ignite-redux-persist@5.10.0` which doesn't exist.  The latest release is actually v1.1.2


This fixes them to install the specified version.

Related to https://github.com/infinitered/ignite/pull/1331
