### PR TITLE
Xcode Simulator not found when running ios from a new Ignite project

### DIFF
--- a/lib/react-native-version.js
+++ b/lib/react-native-version.js
@@ -1,7 +1,7 @@
 const { pathOr, is } = require('ramda')
 
 // the default React Native version for this boilerplate
-const REACT_NATIVE_VERSION = '0.58.3'
+const REACT_NATIVE_VERSION = '0.59.3'
 
 // where the version lives under gluegun
 const pathToVersion = ['parameters', 'options', 'react-native-version']


### PR DESCRIPTION

Update of React Native to fix the simulator issue on macOS https://github.com/infinitered/ignite-andross/issues/263